### PR TITLE
Add Current Day Caching

### DIFF
--- a/source/Untis4GarminActions.mc
+++ b/source/Untis4GarminActions.mc
@@ -1,6 +1,8 @@
 import Toybox.System;
 import Toybox.Time;
 import Toybox.WatchUi;
+import Toybox.Lang;
+import Toybox.Application.Storage;
 
 module Untis4GarminActions {
     const monthDays = [
@@ -52,7 +54,17 @@ module Untis4GarminActions {
     }
 
     public function nextLesson() as Void {
-        if (lessonNumber < apiClient.timetableData.size()) {
+        var timetableData = apiClient.timetableData;
+        var info = Toybox.Time.Gregorian.info(Time.now(), Time.FORMAT_SHORT);
+        var timetableAvailable = apiClient.timetableAvailable;
+        if ((dateD == info.day && dateM == info.month && dateYe == info.year) && apiClient.timetableAvailable == false) {
+            var storageDateString = Lang.format("$1$$2$$3$$4$$5$", [dateYe, "-", dateM, "-", dateD]);
+            timetableData = Storage.getValue(storageDateString);
+            if (timetableData != null) {
+                timetableAvailable = true;
+            }
+        }
+        if (timetableAvailable && lessonNumber < timetableData.size()) {
             lessonNumber++;
             updateLessonNumber = false;
         } else {
@@ -90,4 +102,5 @@ module Untis4GarminActions {
         updateLessonNumber = true;
         WatchUi.requestUpdate();
     }
+
 }


### PR DESCRIPTION
This pull request adds current day caching by storing the timetable returned by the API in the app's local storage.
The feature greatly improves usability in certain conditions where loading the timetable every time takes too long or where Internet access is not guaranteed (e.g. hallways with bad cell reception/WiFi).